### PR TITLE
Release v1.2.28

### DIFF
--- a/src/main/scala/ZCol.scala
+++ b/src/main/scala/ZCol.scala
@@ -455,6 +455,13 @@ class ZCol(currDir : String) extends BorderPanel {
 
 		p += "tag.text" -> tag.text
 		p += "rotated"  -> rotated.toString
+
+		val center = peer.getLayout.asInstanceOf[java.awt.BorderLayout]
+			.getLayoutComponent(java.awt.BorderLayout.CENTER)
+		val divs = if (center != null) collectDividers(center) else Nil
+		p += "wnd.divider.count" -> divs.length.toString
+		divs.zipWithIndex.foreach { case (loc, idx) => p += s"wnd.divider.$idx" -> loc.toString }
+
 		p
 	}
 
@@ -473,6 +480,17 @@ class ZCol(currDir : String) extends BorderPanel {
 			val w = genWnd()
 			this += w
 			w.load(p, prefix + "window." + i.toString + ".")
+		}
+
+		val divCount = p.getOrElse(prefix + "wnd.divider.count", "0").toInt
+		if (divCount > 0) {
+			val divLocs = (0 until divCount).flatMap(i =>
+				p.get(prefix + s"wnd.divider.$i").flatMap(_.toIntOption)).toList
+			SwingUtilities.invokeLater(() => {
+				val center = peer.getLayout.asInstanceOf[java.awt.BorderLayout]
+					.getLayoutComponent(java.awt.BorderLayout.CENTER)
+				if (center != null) applyDividers(center, divLocs)
+			})
 		}
 	}
 }

--- a/src/main/scala/ZPanel.scala
+++ b/src/main/scala/ZPanel.scala
@@ -398,6 +398,17 @@ class ZPanel(initTagText: String) extends BorderPanel {
 				val c = this += new ZCol(currentDir)
 				c.load(p, "column." + i.toString + "." )
 			}
+
+			val divCount = p.getOrElse("col.divider.count", "0").toInt
+			if (divCount > 0) {
+				val divLocs = (0 until divCount).flatMap(i =>
+					p.get(s"col.divider.$i").flatMap(_.toIntOption)).toList
+				SwingUtilities.invokeLater(() => {
+					val center = peer.getLayout.asInstanceOf[java.awt.BorderLayout]
+						.getLayoutComponent(java.awt.BorderLayout.CENTER)
+					if (center != null) applyDividers(center, divLocs)
+				})
+			}
 		}
 	}
 
@@ -424,7 +435,13 @@ class ZPanel(initTagText: String) extends BorderPanel {
 			i = i + 1
 		})
 
-		ZSettings.dump(p, new File(s), "Z Dump") 
+		val center = peer.getLayout.asInstanceOf[java.awt.BorderLayout]
+			.getLayoutComponent(java.awt.BorderLayout.CENTER)
+		val divs = if (center != null) collectDividers(center) else Nil
+		p += "col.divider.count" -> divs.length.toString
+		divs.zipWithIndex.foreach { case (loc, idx) => p += s"col.divider.$idx" -> loc.toString }
+
+		ZSettings.dump(p, new File(s), "Z Dump")
 	}
 }
 


### PR DESCRIPTION
## Changes since v1.2.27

- Persist column divider sizes in Dump/Load: `ZCol` and `ZPanel` now save/restore window pane and column divider positions, complementing the existing window tag divider persistence. All three divider levels (app columns, column windows, window tag) now survive a Dump/Load cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)