### PR TITLE
Release v1.2.29

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Each level has a **tag line** (top, `ZTextArea`) and a **body** (bottom, `ZTextA
 - **`z.scala`** — Entry point (`SwingApplication`). Manages the `MainFrame`, loads/saves `~/.z/settings` (window geometry + tag line defaults), handles OS X fullscreen. Creates the top-level `ZPanel`. On startup, applies `tag.app`/`tag.col`/`tag.wnd`/`tag.cmd` from settings to the live defaults; on exit, reads the existing settings file before writing so user-set keys are not erased.
 - **`ZPanel.scala`** — The application-level panel. Manages a `List[ZCol]` rendered as nested `SplitPane`s. Handles app-level commands (`NewCol`, `Help`, `Dump`, `Load`, `Fonts`, `RotateView`). Dispatches unknown commands down to all columns. `nextCol`/`prevCol` return `Option[ZCol]`. `var rotated` controls whether columns stack left-to-right (`Orientation.Vertical`, default) or top-to-bottom (`Orientation.Horizontal`); `RotateView` toggles it, refreshes, and propagates to all columns. New columns created via `NewCol` inherit the panel's `rotated` state. App-level rotation persisted in `~/.z/settings` as `view.rotated`.
 - **`ZCol.scala`** — A column panel. Manages a `List[ZWnd]` rendered as nested `SplitPane`s. Handles column-level commands (`New`, `Sort`, `CloseCol`, `Lt`/`Rt` for column moves, `RotateView`). Dispatches unknown commands to all its windows. The companion object holds `var colTagLine`, `var wndTagLine`, and `var cmdTagLine` — the mutable defaults that `z.scala` overwrites from `~/.z/settings` at startup. `var rotated` controls whether windows stack top-to-bottom (`Orientation.Horizontal`, default) or side-by-side (`Orientation.Vertical`); persisted via `Dump`/`Load`.
-- **`ZWnd.scala`** — A single editor window (a `SplitPane` with tag on top, body below). Handles file I/O (`Get`/`Put`), external command execution (`< > | !`), interactive process I/O, color/font changes, and all window-level commands. Uses Thread-based callbacks with EDT marshaling (`SwingUtilities.invokeLater`) for async external command output streaming. `cmdProcess` and `cmdProcessWriter` are `Option[...]` types.
+- **`ZWnd.scala`** — A single editor window (a `SplitPane` with tag on top, body below). Handles file I/O (`Get`/`Put`), external command execution (`< > | !`), interactive process I/O, color/font changes, and all window-level commands. Uses Thread-based callbacks with EDT marshaling (`SwingUtilities.invokeLater`) for async external command output streaming. `cmdProcess` and `cmdProcessWriter` are `Option[...]` types. `look(txt, fromTag)` accepts a `fromTag` flag (passed as `true` by tag-line mouse handlers) that tightens the path-prefix guard for tag clicks (see Window Path Segment Navigation).
 - **`ZTextArea.scala`** — Extended `swing.TextArea` with undo/redo (`UndoManager`), brace matching (Ctrl+B1), dirty tracking via `ZDirtyTextEvent`/`ZCleanTextEvent`, and helper methods for line/selection manipulation.
 - **`ZUtilities.scala`** — Static utilities: text selection logic, brace/symbol matching (`symMatch`), external process launching (`extCmd`), and shell command tokenization (handles single-quoted tokens).
 - **`ZFonts.scala`** — Registers bundled fonts (Hack, Bitstream Vera) from classpath resources.
@@ -59,6 +59,15 @@ Components communicate upward via Scala Swing's `publish`/`listenTo` reactor pat
 - Each level's `command()` method handles its own commands and delegates unknown ones to child components
 - The `%` prefix forces text to be treated as a command (bypasses look logic)
 - External commands: `< cmd` (replace/insert stdout), `> cmd` (send selection as stdin), `| cmd` (pipe selection), `! cmd` (replace all content)
+
+### Relative Path Navigation (B3 on tag or body)
+
+When a window has a relative `rawPath`, any B3 navigation that resolves to a path under `root` will open the new window with a relative tag rather than an absolute one. The resolved absolute path (`ep`) is stripped of the `root` prefix before being passed to `lookUpward`. This applies uniformly — directory listings, body text references, and tag path segments all produce relative-tagged windows.
+
+`isWndPathPrefix` is a narrower condition used only for **resolution base** (`resolveBase`): when clicking a segment of the tag line's own path (e.g. `main` in `src/main/Foo.scala`), resolution must use `root` rather than `baseDir` to avoid a double-prefix. Guards:
+- `rawPath` is relative
+- The extracted text is a prefix of `rawPath`
+- **Tag only** (`fromTag=true`): the extracted text starts at position 0 of the tag line, ruling out command arguments that coincidentally share the same path prefix
 
 ### Scratch Buffers
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ sbt test
 - **Brace matching** — Ctrl+B1 selects the region between matching `{}` `[]` `()` `<>` or any delimiter pair
 - **Line numbers** — toggle with `Ln`
 - **Path expansion** — tag lines and commands support `~`, `./`, and `../` prefixes
+- **Relative path style preservation** — when a window has a relative path, B3 navigation (directory listings, body text, tag path segments) opens new windows with relative tags rather than absolute paths, keeping the project-relative style consistent
 - **Root directory control** — `Dir <path>` changes where relative paths resolve, where external commands run, and the LSP workspace root; works from window, column, or app tag line
 - **User scripts** — place executable scripts in `.z/scripts/` (project-local) or `~/.z/scripts/` (global) and invoke them from any tag line with a comma prefix: `,Build`, `,Format`, `,Deploy`. Use `,,cmd` to run on every open window. Additional directories can be configured in `~/.z/scripts.conf`
 - **Font control** — `Font`/`FONT` set the variable/fixed-width body font; `TagFont` sets the tag line font. All three cascade from the app tag line (sets editor-wide default), column tag line (that column), or window tag line (that window only)

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -146,6 +146,21 @@ This cascade is elegant. B3 on `main.go` opens `main.go`. B3 on `:42` jumps to l
 
 Like B2, B3 also works as a drag gesture: hold B3, drag to select, release to act on the selection.
 
+### Relative Path Style Preservation
+
+When a window has a relative path, B3 navigation preserves that style — any path opened from it gets a relative tag rather than an absolute one. This applies uniformly: directory listings, paths in body text, and tag path segments all behave consistently.
+
+For example, a directory window showing `src/main`:
+
+| You B3-click | New window tag |
+|-------------|---------------|
+| `Foo.scala` in the listing | `src/main/Foo.scala` |
+| `util/` in the listing | `src/main/util` |
+| `main` in the tag line | `src/main` |
+| `src` in the tag line | `src` |
+
+In the tag line, this applies only to the path at the very start. Relative paths appearing later in the tag — such as arguments to `Get` or other commands — resolve normally (relative to the file's parent directory).
+
 ### Forcing a Command with `%`
 
 Sometimes z's smart B3 gets in the way. If you have a word like `Put` in a file you're editing and you want to *run* it rather than search for it, prefix it with `%`:

--- a/src/main/resources/help/main.txt
+++ b/src/main/resources/help/main.txt
@@ -46,6 +46,17 @@ MOUSE BUTTONS
                   · Prefix it with %  e.g.  %Put  or  %ls -la
                   · Or place the caret at the end of the file before acting
 
+                Relative path style preservation:
+                  When the current window has a relative path, any B3 navigation that
+                  resolves to a path under the window's root will open the new window
+                  with a relative tag rather than an absolute one.
+                  Example: a directory window showing src/main — B3-clicking Foo.scala
+                  opens src/main/Foo.scala, not /home/user/project/src/main/Foo.scala.
+                  Tag path segment clicks also benefit: clicking "main" in the tag
+                  src/main/Foo.scala opens src/main (resolved against root).
+                  In the tag line, this applies only to the path at the very start;
+                  relative paths in command arguments are unaffected.
+
     B3+drag     Select text, then on release perform the B3 action on the selection
     B2+drag     Select text, then on release execute the selection as a command
 

--- a/src/main/scala/ZWnd.scala
+++ b/src/main/scala/ZWnd.scala
@@ -127,7 +127,7 @@ class ZWnd(initTagText : String, initBodyText : String = "", currDir : String = 
 				e.source match {
 					case ta: ZTextArea =>
 						if(SwingUtilities.isMiddleMouseButton(e.peer))  command(ZUtilities.selectedText(ta, e))
-						else if(SwingUtilities.isRightMouseButton(e.peer))  look(ZUtilities.selectedText(ta, e))
+						else if(SwingUtilities.isRightMouseButton(e.peer))  look(ZUtilities.selectedText(ta, e), ta == tag)
 					case _ =>
 				}
 			}
@@ -193,7 +193,7 @@ class ZWnd(initTagText : String, initBodyText : String = "", currDir : String = 
 					e.source match {
 						case ta: ZTextArea =>
 							val txt = ZUtilities.selectedText(ta, e)
-							if(!look(txt)) command(txt)
+							if(!look(txt, ta == tag)) command(txt)
 						case _ =>
 					}
 				} catch {
@@ -313,12 +313,10 @@ class ZWnd(initTagText : String, initBodyText : String = "", currDir : String = 
 		}
 	}
 
-	def look(txt: String) : Boolean  = {
+	def look(txt: String, fromTag: Boolean = false) : Boolean  = {
 		if(txt == null || txt.trim.isEmpty)  return true
 
-		var stxt = ""
-		var loc = ""
-
+		// Early-return cases: line number and regexp search
 		txt match {
 			case ZWnd.reLineNo(no) =>
 				var i = no.toInt
@@ -331,41 +329,36 @@ class ZWnd(initTagText : String, initBodyText : String = "", currDir : String = 
 				}
 				return false
 			case ZWnd.reRegExp(re) =>
-				stxt = re
-
-				var pos = body.caret.position
-				var t = body.text.substring(pos)
-				var p = ZWnd.compiledPattern(stxt)
-				var m = p.matcher(t)
-
+				val pos = body.caret.position
+				val t   = body.text.substring(pos)
+				val m   = ZWnd.compiledPattern(re).matcher(t)
 				if(m.find())  {
 					body.caret.dot = pos + m.start()
 					body.caret.moveDot(pos + m.end())
 					body.requestFocus()
 					return true
 				}
-
 				return false
-			case ZWnd.reFilePath(f, l) =>
-				stxt = f
-				loc = l
-			case ZWnd.reFilePath2(f, l) =>
-				stxt = f
-				loc = l
-			case ZWnd.reQuotedFilePath(f, l) =>
-				stxt = f
-				loc = l
-			case ZWnd.reQuotedFilePath2(f, l) =>
-				stxt = f
-				loc = l
 			case _ =>
-				stxt = txt
 		}
 
-		val sp = ZUtilities.expandPath(stxt, root)
+		// Path cases: extract file and optional location suffix
+		val (stxt, loc) = txt match {
+			case ZWnd.reFilePath(f, l)        => (f, l)
+			case ZWnd.reFilePath2(f, l)       => (f, l)
+			case ZWnd.reQuotedFilePath(f, l)  => (f, l)
+			case ZWnd.reQuotedFilePath2(f, l) => (f, l)
+			case _                            => (txt, "")
+		}
+
+		val sp      = ZUtilities.expandPath(stxt, root)
 		val absPath = new File(path)
 		val baseDir = if (absPath.isDirectory) path else absPath.getParent
-		val ep = (if(ZUtilities.isFullPath(sp)) "" else (baseDir + ZUtilities.separator)) + sp
+		val isWndPathPrefix = !ZUtilities.isFullPath(rawPath) &&
+		                      rawPath.startsWith(stxt) &&
+		                      (!fromTag || tag.text.startsWith(stxt))
+		val resolveBase = if (isWndPathPrefix) root else baseDir
+		val ep = (if(ZUtilities.isFullPath(sp)) "" else (resolveBase + ZUtilities.separator)) + sp
 
 		if(new File(ep).exists)
 		{
@@ -373,20 +366,22 @@ class ZWnd(initTagText : String, initBodyText : String = "", currDir : String = 
 			{
 				path = ep
 				command("Get")
-				if(loc != null && !loc.isEmpty) look(loc)
+				if(loc.nonEmpty) look(loc)
 			}
 			else
 			{
-				lookUpward(ep + loc)
+				val lookPath = if (!ZUtilities.isFullPath(rawPath) && ep.startsWith(root + ZUtilities.separator))
+				                   ep.substring(root.length + 1)
+				               else ep
+				lookUpward(lookPath + loc)
 			}
 
 			return true
 		}
 
-		var pos = body.caret.position
-		var t = body.text.substring(pos)
-		var p = Pattern.compile(stxt, Pattern.MULTILINE)
-		var m = p.matcher(t)
+		val pos = body.caret.position
+		val t   = body.text.substring(pos)
+		val m   = Pattern.compile(stxt, Pattern.MULTILINE).matcher(t)
 
 		if(m.find() && m.end() > m.start())  {
 			body.caret.dot = pos + m.start()


### PR DESCRIPTION
## Summary
- Relative-path-preserving B3 navigation: when a window has a relative path, B3 navigation (directory listings, body text, tag path segments) opens new windows with relative tags rather than absolute paths
- Tag path segment clicks resolve correctly against root to avoid double-prefix bugs
- `look()` refactored: split early-return cases from path cases, `var` → `val` throughout

## Test plan
- [ ] Open a directory window with a relative path; B3-click a file in the listing — new window should show a relative tag
- [ ] B3-click a subdirectory in the listing — new window should show a relative tag
- [ ] B3-click a path segment in the tag line (e.g. `main` in `src/main/Foo.scala`) — should open `src/main` with relative tag
- [ ] B3-click a path in a window with an absolute tag — should still open with absolute tag
- [ ] B3-click command arguments in the tag line — should not be affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)