### PR TITLE
Release v1.3.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ Components communicate upward via Scala Swing's `publish`/`listenTo` reactor pat
 - **B2 drag** on text: calls `command()` directly
 - Each level's `command()` method handles its own commands and delegates unknown ones to child components
 - The `%` prefix forces text to be treated as a command (bypasses look logic)
-- External commands: `< cmd` (replace/insert stdout), `> cmd` (send selection as stdin), `| cmd` (pipe selection), `! cmd` (replace all content)
+- External commands: `< cmd` (replace selection or insert stdout at caret), `> cmd` (send selection as stdin), `| cmd` (pipe selection or full body), `! cmd` (replace all content)
 
 ### Relative Path Navigation (B3 on tag or body)
 
@@ -75,14 +75,16 @@ Files with `+` in the path prefix (e.g., `+scratch`, `+Results`) are never saved
 
 ### Keyboard Capture Mode
 
-`ZTextArea` has a **capture mode** API: `startCapture()`, `endCapture(): String`, `abortCapture()`. `ZWnd` manages the state (`captureActive: Boolean`, `captureTA: ZTextArea`) and exposes `cancelCapture()`.
+`ZTextArea` has a **capture mode** API: `startCapture()`, `endCapture(): String`, `abortCapture()`. `ZWnd` manages the state via `captureTA: Option[ZTextArea] = None` (presence means active) and exposes `cancelCapture()`.
 
 - **Ctrl+Enter** — if text is selected: executes it as a command (no deletion). If capture is active: ends capture and executes. Otherwise: starts capture, recording the caret position. Everything typed from that point is highlighted via a Swing `Highlighter` (using `peer.getSelectionColor` so it follows the active theme). The `Highlighter` + `CaretListener` approach is synchronous (no `invokeLater`), no flicker.
 - **Ctrl+F** — if text is selected: performs a look on it (no deletion). If capture is active: ends capture and performs a look. No-op outside capture with no selection.
 - **Escape** — cancels capture (no execution, text stays).
 - Body capture text is deleted after execution (`replaceSelection("")`); tag capture text stays and remains selected.
 - `endCapture()` converts the Highlighter region to a real Swing selection before returning, so `replaceSelection("")` and natural selection persistence both work correctly.
-- **Ctrl+P** (was Ctrl+F) opens the file-chooser path picker in `ZWnd`, `ZCol`, and `ZPanel`.
+- **Ctrl+P** opens the file-chooser path picker in `ZWnd`, `ZCol`, and `ZPanel`.
+- **`< cmd` in capture mode**: `externalCmd` accepts `insertPos: Option[Int]`; for `<`, this is always `Some(body.peer.getCaretPosition)` captured synchronously at call time, and output is inserted via `peer.getDocument.insertString(pos, s, null)` using an `AtomicInteger` to advance the offset across multiple `invokeLater` callbacks. Scroll mode does not affect placement.
+- **`| cmd` in capture mode**: after `endCapture()` + `replaceSelection("")` clears the body selection, `body.peer.selectAll()` is called so that `|` receives the full body content as stdin rather than an empty string.
 
 ### Session Persistence
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,17 @@ When a window has a relative `rawPath`, any B3 navigation that resolves to a pat
 
 Files with `+` in the path prefix (e.g., `+scratch`, `+Results`) are never saved to disk. They appear in `Dump` state but `Put` is a no-op on them.
 
+### Keyboard Capture Mode
+
+`ZTextArea` has a **capture mode** API: `startCapture()`, `endCapture(): String`, `abortCapture()`. `ZWnd` manages the state (`captureActive: Boolean`, `captureTA: ZTextArea`) and exposes `cancelCapture()`.
+
+- **Ctrl+Enter** — if text is selected: executes it as a command (no deletion). If capture is active: ends capture and executes. Otherwise: starts capture, recording the caret position. Everything typed from that point is highlighted via a Swing `Highlighter` (using `peer.getSelectionColor` so it follows the active theme). The `Highlighter` + `CaretListener` approach is synchronous (no `invokeLater`), no flicker.
+- **Ctrl+F** — if text is selected: performs a look on it (no deletion). If capture is active: ends capture and performs a look. No-op outside capture with no selection.
+- **Escape** — cancels capture (no execution, text stays).
+- Body capture text is deleted after execution (`replaceSelection("")`); tag capture text stays and remains selected.
+- `endCapture()` converts the Highlighter region to a real Swing selection before returning, so `replaceSelection("")` and natural selection persistence both work correctly.
+- **Ctrl+P** (was Ctrl+F) opens the file-chooser path picker in `ZWnd`, `ZCol`, and `ZPanel`.
+
 ### Session Persistence
 
 `Dump [fname]` serializes the full editor state (all columns, windows, content of dirty scratch buffers, fonts, colors) to a flat key=value file via `ZSettings`. `Load [fname]` restores it.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ sbt test
 
 ## Features
 
-- **Acme-style mouse chording** — B3 (right-click) to look/navigate/execute, B2-drag to execute selected text
+- **Acme-style mouse chording** — B3 (right-click) to look/navigate/execute, B2-drag to execute selected text; **keyboard capture mode** (Ctrl+Enter) lets you type a command with the keyboard, see it highlighted as you go, then execute as a command (Ctrl+Enter) or look/navigate (Ctrl+F)
 - **Syntax highlighting** — powered by RSyntaxTextArea; use `Hilite` to enable, `Hilite [lang]` for a specific language, `Theme [name]` to switch colour themes
 - **Language Server Protocol (LSP)** — use `Lsp` to start a language server for the current file:
   - Squiggly underlines for errors and warnings

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -337,9 +337,9 @@ This is where z becomes genuinely powerful. Rather than embedding a terminal emu
 
 There are four external command operators, each with a distinct relationship between the command, the selection, and the output.
 
-### `< cmd` — Replace With Output
+### `< cmd` — Replace Selection or Insert at Caret
 
-The `<` operator runs *cmd* and **replaces the current selection** (or inserts at the caret if nothing is selected) with the command's standard output.
+The `<` operator runs *cmd* and **replaces the current selection with its standard output**, or inserts at the caret position if nothing is selected. `Scroll` mode does not affect placement.
 
 ```
 < date
@@ -347,7 +347,7 @@ The `<` operator runs *cmd* and **replaces the current selection** (or inserts a
 < git log --oneline -10
 ```
 
-Practical use: you have a placeholder in a file that should be replaced with generated content. Select it, then run `< myscript.py` to replace it in place.
+Practical use: select a placeholder in a file and run `< myscript.py` to replace it with generated content, or position the caret and run `< myscript.py` to insert inline.
 
 ### `> cmd` — Send Selection as Input
 
@@ -363,7 +363,7 @@ Practical use: select a JSON blob and run `> jq .` to pretty-print it in `+Resul
 
 ### `| cmd` — Pipe Through
 
-The `|` operator **pipes the selection through** *cmd* and **replaces the selection with the output**. The selection goes in as stdin; stdout replaces it.
+The `|` operator **pipes the selection through** *cmd* and **replaces the selection with the output**. The selection goes in as stdin; stdout replaces it. With no selection (e.g. in capture mode), the entire body content is piped and replaced with the output.
 
 ```
 | sort
@@ -541,6 +541,8 @@ z creates several scratch buffers automatically:
 ### Controlling Scroll Behaviour
 
 By default, z scrolls a window as new content arrives. For a `+Results` window receiving a lot of output, this can be distracting. Execute `Scroll off` from the window's tag line to stop auto-scrolling — the content still streams in, but the view stays put. `Scroll on` restores the default.
+
+> **Note:** `Scroll` mode applies to `>`, `|`, and `!` output only. The `<` operator replaces the selection (or inserts at the caret) and is unaffected by the scroll setting.
 
 ---
 
@@ -1055,7 +1057,7 @@ Everything is back: every window, every scratch buffer, every colour setting. Re
 |---------|-------|--------|
 | `< cmd` | — | Replaces selection (or inserts at caret) |
 | `> cmd` | Selection (or full file) | `+Results` window |
-| `\| cmd` | Selection | Replaces selection |
+| `\| cmd` | Selection (or full body) | Replaces selection (or full body) |
 | `! cmd` | — | Replaces window (or new window from col/app) |
 | `X 'pat' cmd` | — | Runs cmd in matching windows |
 | `Y 'pat' cmd` | — | Runs cmd in non-matching windows |

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -175,6 +175,32 @@ The `%` tells z: skip the look/search logic, treat this as a command directly.
 
 > **Tip:** Placing the caret at the very end of the file also bypasses look logic — another way to force command execution.
 
+### Keyboard Capture Mode
+
+B2 and B3 require mouse precision for multi-word commands. Capture mode lets you type a command with the keyboard, see it highlighted as you go, then choose how to execute it.
+
+**Press `Ctrl+Enter`** to start capture mode. Everything you type from that point is highlighted as you type. When you're ready:
+
+- **`Ctrl+Enter`** — execute the captured text as a command (B2 analog)
+- **`Ctrl+F`** — look/navigate on the captured text (B3 analog: opens files, jumps to lines, searches)
+- **`Escape`** — cancel without executing; the typed text stays
+
+If text is already selected when you press `Ctrl+Enter` or `Ctrl+F`, the shortcuts act on that selection immediately — no capture mode is entered, and the selection is not deleted.
+
+**Body vs. tag behaviour:**
+- In the **body**: the typed command text is deleted after execution (it was a transient command prompt, not content).
+- In the **tag**: the text stays and remains highlighted after execution, just like a B3-click on a tag command.
+
+**Example — change the font without leaving the keyboard:**
+1. Press `Ctrl+Enter` in any body → capture mode on.
+2. Type `Font Hack 16` → text appears, highlighted as you type.
+3. Press `Ctrl+Enter` → font changes, typed text deleted.
+
+**Example — open a file by typing its path:**
+1. Press `Ctrl+Enter` → capture mode on.
+2. Type `src/main/z.scala` → highlighted.
+3. Press `Ctrl+F` → file opens, path text deleted from body.
+
 ### Putting It Together
 
 Once these three buttons become second nature, z starts to feel very fast. You select with B1, execute with B2, navigate with B3 — and your hands almost never leave the mouse for the common operations of an editing session.
@@ -983,7 +1009,9 @@ Everything is back: every window, every scratch buffer, every colour setting. Re
 | `Ctrl+Home` / `Ctrl+End` | Top / Bottom |
 | `Ctrl+Left` / `Ctrl+Right` | Prev / Next word |
 | `Ctrl+Backspace` / `Ctrl+Delete` | Delete word left / right |
-| `Ctrl+F` | File chooser at caret |
+| `Ctrl+Enter` | Execute selection as command, or toggle capture mode |
+| `Ctrl+F` | Look on selection, or end capture mode as look |
+| `Ctrl+P` | File chooser at caret |
 | `Ctrl+Space` | LSP completion |
 
 ### File Commands

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ val test         = "org.scalatest"          %% "scalatest" % "3.2.18" % "test"
 
 
 lazy val commonSettings = Seq(
-  version := "1.0.0",
+  version := "1.2.30",
   scalaVersion := "3.8.2",
   scalacOptions += "-no-indent"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ val test         = "org.scalatest"          %% "scalatest" % "3.2.18" % "test"
 
 
 lazy val commonSettings = Seq(
-  version := "1.2.30",
+  version := "1.3.0",
   scalaVersion := "3.8.2",
   scalacOptions += "-no-indent"
 )

--- a/src/main/resources/help/main.txt
+++ b/src/main/resources/help/main.txt
@@ -148,10 +148,16 @@ EDITING COMMANDS
 
 EXTERNAL COMMANDS
 
-    < cmd       Replace the current selection (or insert at caret) with cmd's stdout
+    < cmd       Replace the current selection with cmd's stdout, or insert at the
+                caret if nothing is selected.  Scroll mode does not affect placement.
+
     > cmd       Send the current selection (or full text if nothing selected) as stdin to cmd;
                 output goes to a +Results window
-    | cmd       Pipe the selection through cmd; replace selection with stdout
+
+    | cmd       Pipe the current selection through cmd; replace the selection with stdout.
+                With no selection (e.g. in capture mode): pipes the entire body content
+                and replaces it with the output.
+
     ! cmd       Run cmd and replace the entire window content with its output
                 From the app tag line: output goes to a new window in the rightmost column
                 From a column tag line: output goes to a new window in that column

--- a/src/main/resources/help/main.txt
+++ b/src/main/resources/help/main.txt
@@ -1,6 +1,6 @@
 Z — Plan 9 Acme-Inspired Editor
 ================================
-Version: 1.2.30
+Version: 1.3.0
 
 USAGE
 

--- a/src/main/resources/help/main.txt
+++ b/src/main/resources/help/main.txt
@@ -61,6 +61,20 @@ MOUSE BUTTONS
     B3+drag     Select text, then on release perform the B3 action on the selection
     B2+drag     Select text, then on release execute the selection as a command
 
+    Ctrl+Enter  If text is already selected: execute it as a command (B2 analog).
+                Otherwise: enter capture mode — mark the current position.
+                Everything typed from that point is highlighted as you go. End with:
+                  Ctrl+Enter  execute the captured text as a command
+                  Ctrl+F      execute the captured text as a look/navigate (B3 analog)
+                  Escape      cancel without executing (typed text stays)
+                Body: typed capture text is deleted after execution.
+                Tag:  typed capture text stays and remains highlighted after execution.
+
+    Ctrl+F      If text is already selected: look/navigate on it (B3 analog).
+                If capture mode is active: end capture and look/navigate on the
+                captured text (body text deleted on success; tag text stays).
+                Outside capture mode with no selection: no-op.
+
     Ctrl+B1     Brace/symbol matching selection.  Matched pairs: {}  <>  ()  []
                 Any other character is used as both the open and close delimiter.
 
@@ -301,7 +315,9 @@ KEYBOARD SHORTCUTS
 
     Tools
       Ctrl+B1                       Brace/symbol matching selection
-      Ctrl+F                        Open a file-chooser to complete the path at the caret
+      Ctrl+Enter                    Execute selection as command, or toggle capture mode
+      Ctrl+F                        Look/navigate on selection, or end capture as look
+      Ctrl+P                        Open a file-chooser to complete the path at the caret
       Ctrl+Space                    LSP code completion (requires Lsp to be active)
 
 

--- a/src/main/resources/help/main.txt
+++ b/src/main/resources/help/main.txt
@@ -1,5 +1,6 @@
 Z — Plan 9 Acme-Inspired Editor
 ================================
+Version: 1.2.30
 
 USAGE
 

--- a/src/main/scala/ZCol.scala
+++ b/src/main/scala/ZCol.scala
@@ -204,7 +204,7 @@ class ZCol(currDir : String) extends BorderPanel {
 
 	listenTo(tag.keys)
 	reactions += {
-		case e : KeyPressed if((e.key == Key.F) && e.peer.isControlDown()) =>	
+		case e : KeyPressed if((e.key == Key.P) && e.peer.isControlDown()) =>
 			var p = ZUtilities.selectedText(tag, tag.caret.dot)
 			if(p.isEmpty)  p = "."
 

--- a/src/main/scala/ZPanel.scala
+++ b/src/main/scala/ZPanel.scala
@@ -122,7 +122,7 @@ class ZPanel(initTagText: String) extends BorderPanel {
 
 	listenTo(tag.keys)
 	reactions += {
-		case e : KeyPressed if((e.key == Key.F) && e.peer.isControlDown()) =>	
+		case e : KeyPressed if((e.key == Key.P) && e.peer.isControlDown()) =>
 			var p = ZUtilities.selectedText(tag, tag.caret.dot)
 			if(p.isEmpty) p = "."
 		

--- a/src/main/scala/ZTextArea.scala
+++ b/src/main/scala/ZTextArea.scala
@@ -25,7 +25,8 @@ import swing.event.{MouseEntered, MouseClicked, Key, KeyReleased, Event}
 import java.awt.Color
 import java.awt.event.{KeyEvent, InputEvent}
 import javax.swing.{SwingUtilities, KeyStroke}
-import javax.swing.event.{UndoableEditListener, UndoableEditEvent}
+import javax.swing.event.{UndoableEditListener, UndoableEditEvent, CaretListener}
+import javax.swing.text.DefaultHighlighter
 import org.fife.ui.rsyntaxtextarea.{RSyntaxTextArea, SyntaxConstants}
 
 class ZTextArea(txt : String = "", wrap : Boolean = false) extends TextArea(txt) {
@@ -54,6 +55,9 @@ class ZTextArea(txt : String = "", wrap : Boolean = false) extends TextArea(txt)
 	peer.getInputMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_Z, InputEvent.CTRL_DOWN_MASK), "none")
 	peer.getInputMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_Z, InputEvent.CTRL_DOWN_MASK | InputEvent.SHIFT_DOWN_MASK), "none")
 	peer.getInputMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_Y, InputEvent.CTRL_DOWN_MASK), "none")
+	// Reserve Ctrl+Enter (capture execute) and Ctrl+F (capture look) — suppress RSTA defaults to avoid beep
+	peer.getInputMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, InputEvent.CTRL_DOWN_MASK), "none")
+	peer.getInputMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_F, InputEvent.CTRL_DOWN_MASK), "none")
 
 	listenTo(mouse.moves, mouse.clicks)
 	reactions += {
@@ -115,6 +119,57 @@ class ZTextArea(txt : String = "", wrap : Boolean = false) extends TextArea(txt)
 	def selectionEnd_=(i: Int)                = peer.setSelectionEnd(i)
 	def linePrefix(offset : Int = caret.dot)  = getTextRange(lineStart(lineNo(offset)), offset)
 	def braceMatch(e: MouseClicked)           = ZUtilities.symMatch(this, e)
+
+	private var captureModeActive = false
+	private var captureStartPos = -1
+	private var captureHighlight: Option[AnyRef] = None
+	private var captureCaretListener: Option[CaretListener] = None
+
+	private def clearCapture(): Unit = {
+		captureModeActive = false
+		captureCaretListener.foreach(peer.removeCaretListener); captureCaretListener = None
+		captureHighlight.foreach(peer.getHighlighter.removeHighlight); captureHighlight = None
+	}
+
+	def startCapture(): Unit = {
+		// Light-text areas (e.g. white tag): darken the background so typed text stays visible.
+		// Dark-text areas (e.g. black body): the selection color already contrasts well.
+		val fg = peer.getForeground
+		val brightness = (fg.getRed + fg.getGreen + fg.getBlue) / (3.0 * 255)
+		val highlightColor = if(brightness > 0.5) {
+			val bg = peer.getBackground
+			new Color((bg.getRed * 0.65).toInt, (bg.getGreen * 0.65).toInt, (bg.getBlue * 0.65).toInt)
+		} else {
+			peer.getSelectionColor
+		}
+		val painter = new DefaultHighlighter.DefaultHighlightPainter(highlightColor)
+		captureModeActive = true
+		captureStartPos = peer.getCaretPosition
+		captureHighlight = try { Some(peer.getHighlighter.addHighlight(captureStartPos, captureStartPos, painter)) }
+		                   catch { case _: Throwable => None }
+		val listener: CaretListener = _ => {
+			if(captureModeActive) captureHighlight.foreach { h =>
+				val pos = peer.getCaretPosition
+				try { peer.getHighlighter.changeHighlight(h, captureStartPos min pos, captureStartPos max pos) }
+				catch { case _: Throwable => () }
+			}
+		}
+		captureCaretListener = Some(listener)
+		peer.addCaretListener(listener)
+	}
+
+	def endCapture(): String = {
+		clearCapture()
+		val pos   = peer.getCaretPosition
+		val start = captureStartPos min pos
+		val end   = captureStartPos max pos
+		// Apply real Swing selection: body caller can replaceSelection(""), tag selection persists naturally
+		peer.setCaretPosition(start)
+		peer.moveCaretPosition(end)
+		if(end > start) peer.getText(start, end - start) else ""
+	}
+
+	def abortCapture(): Unit = clearCapture()
 
 	def colors(back : Color, fore : Color, crt : Color, backSel : Color, foreSel : Color): Unit = {
 		background = back

--- a/src/main/scala/ZWnd.scala
+++ b/src/main/scala/ZWnd.scala
@@ -456,9 +456,22 @@ class ZWnd(initTagText : String, initBodyText : String = "", currDir : String = 
 				}
 			case _ => cmd
 		}
-		// For <, always insert at the current caret position (not at end of document)
-		val insertAt = (if(op == "<") insertPos.orElse(Some(body.peer.getCaretPosition)) else insertPos)
-		               .map(new AtomicInteger(_))
+		val insertAt = if (op == "<") {
+			if (insertPos.isDefined) {
+				insertPos.map(new AtomicInteger(_))
+			} else {
+				val selStart = body.peer.getSelectionStart
+				val selEnd   = body.peer.getSelectionEnd
+				if (selStart != selEnd) {
+					body.peer.replaceSelection("")
+					Some(new AtomicInteger(selStart))
+				} else {
+					Some(new AtomicInteger(body.peer.getCaretPosition))
+				}
+			}
+		} else {
+			insertPos.map(new AtomicInteger(_))
+		}
 		val onOutput: String => Unit = s => SwingUtilities.invokeLater(() => {
 			insertAt match {
 				case Some(pos) =>
@@ -491,9 +504,18 @@ class ZWnd(initTagText : String, initBodyText : String = "", currDir : String = 
 				case "<" => ZUtilities.extCmd(resolved, onOutput, onDone, redirectErrStream = true, workdir = Some(wd), env = Some(env))
 				case ">" => ZUtilities.extCmd(resolved, onOutput, onDone, redirectErrStream = true, input = in, workdir = Some(wd), env = Some(env))
 				case "|" =>
-					val sel = Option(body.selected).getOrElse("")
-					body.selected = ""
-					ZUtilities.extCmd(resolved, onOutput, onDone, redirectErrStream = true, input = Some(sel), workdir = Some(wd), env = Some(env))
+					val selStart = body.peer.getSelectionStart
+					val selEnd   = body.peer.getSelectionEnd
+					val input = if (selStart != selEnd) {
+						val sel = body.selected
+						body.selected = ""
+						sel
+					} else {
+						val content = body.text
+						body.text = ""
+						content
+					}
+					ZUtilities.extCmd(resolved, onOutput, onDone, redirectErrStream = true, input = Some(input), workdir = Some(wd), env = Some(env))
 				case "!" =>
 					body.text = ""
 					ZUtilities.extCmd(resolved, onOutput, onDone, redirectErrStream = true, workdir = Some(wd), env = Some(env))

--- a/src/main/scala/ZWnd.scala
+++ b/src/main/scala/ZWnd.scala
@@ -31,6 +31,7 @@ import java.awt.{Font, Color}
 import java.awt.ComponentOrientation.RIGHT_TO_LEFT
 import javax.swing.text.{Utilities, DefaultCaret}
 import javax.swing.{JOptionPane, ScrollPaneConstants, SwingUtilities}
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.regex.Pattern
 import org.fife.ui.rsyntaxtextarea.SyntaxConstants
 
@@ -62,6 +63,7 @@ class ZWnd(initTagText : String, initBodyText : String = "", currDir : String = 
 	var cmdProcessWriter : Option[BufferedWriter] = None
 	var dragSel = false
 	var dragSelMark = -1
+	var captureTA: Option[ZTextArea] = None
 
 	val tag = new ZTextArea(initTagText, true)
 	tag.font = ZFonts.defaultTag
@@ -135,9 +137,14 @@ class ZWnd(initTagText : String, initBodyText : String = "", currDir : String = 
 			dragSelMark = -1
 	}
 
+	def cancelCapture(): Unit = {
+		captureTA.foreach(_.abortCapture())
+		captureTA = None
+	}
+
 	listenTo(tag.keys, body.keys)
 	reactions += {
-		case e : KeyPressed if((e.key == Key.F) && e.peer.isControlDown()) =>
+		case e : KeyPressed if((e.key == Key.P) && e.peer.isControlDown()) =>
 			val ta = if(e.source.hashCode == tag.hashCode) tag else body
 			var p = path
 
@@ -166,13 +173,56 @@ class ZWnd(initTagText : String, initBodyText : String = "", currDir : String = 
 			}
 
 		case e : KeyReleased =>
-			if(e.key == Key.Enter && indInteractive && cmdProcess.isDefined) {
+			// Ctrl+Enter: execute existing selection as command, or start/end capture mode
+			if(e.key == Key.Enter && e.peer.isControlDown()) {
+				captureTA match {
+					case Some(ta) =>
+						val txt     = ta.endCapture().trim
+						val wasBody = ta == body
+						captureTA = None
+						if(txt.nonEmpty) {
+							if(wasBody) body.peer.replaceSelection("")
+							// | needs a body selection; after deleting capture text, select all remaining body
+							if(wasBody && txt.startsWith("|")) body.peer.selectAll()
+							command(txt)
+						}
+					case None =>
+						val activeTA = if(e.source.hashCode == tag.hashCode) tag else body
+						val sel = Option(activeTA.selected).getOrElse("").trim
+						if(sel.nonEmpty) command(sel)
+						else { captureTA = Some(activeTA); activeTA.startCapture() }
+				}
+			}
+			// Ctrl+F: look on existing selection, or end capture mode as look
+			if(e.key == Key.F && e.peer.isControlDown() && !e.peer.isShiftDown()) {
+				captureTA match {
+					case Some(ta) =>
+						val txt     = ta.endCapture().trim
+						val wasBody = ta == body
+						// Save capture bounds before look() changes the selection
+						val capStart = body.peer.getSelectionStart
+						val capEnd   = body.peer.getSelectionEnd
+						captureTA = None
+						if(txt.nonEmpty) {
+							val found = look(txt, !wasBody)
+							// Delete by position — replaceSelection() would delete whatever look() selected
+							if(found && wasBody) body.peer.getDocument.remove(capStart, capEnd - capStart)
+						}
+					case None =>
+						val activeTA = if(e.source.hashCode == tag.hashCode) tag else body
+						val sel = Option(activeTA.selected).getOrElse("").trim
+						if(sel.nonEmpty) look(sel, activeTA == tag)
+				}
+			}
+			if(e.key == Key.Escape) cancelCapture()
+
+			if(e.key == Key.Enter && !e.peer.isControlDown() && indInteractive && cmdProcess.isDefined) {
 				body.line(body.currLineNo - 1) match {
 					case ZWnd.rePrompt(cmd) =>
 						cmdProcessWriter.foreach { w => w.write(cmd); w.newLine(); w.flush() }
 					case _ => /* Do nothing, if not a valid prompt and command */
 				}
-			} else if(e.key == Key.Enter && indIndent) {
+			} else if(e.key == Key.Enter && !e.peer.isControlDown() && indIndent) {
 				val p = body.line(body.currLineNo - 1)
 				p match {
 					case ZWnd.reWhiteSpace(spc) => body.selected = spc
@@ -394,7 +444,7 @@ class ZWnd(initTagText : String, initBodyText : String = "", currDir : String = 
 		return true
 	}
 
-	def externalCmd(op : String, cmd : String, in : Option[String] = None) : Option[Process] = {
+	def externalCmd(op : String, cmd : String, in : Option[String] = None, insertPos : Option[Int] = None) : Option[Process] = {
 		val resolved = cmd.trim match {
 			case ZScripts.reScript(name, args) =>
 				ZScripts.resolve(name, rootPath) match {
@@ -406,12 +456,19 @@ class ZWnd(initTagText : String, initBodyText : String = "", currDir : String = 
 				}
 			case _ => cmd
 		}
+		// For <, always insert at the current caret position (not at end of document)
+		val insertAt = (if(op == "<") insertPos.orElse(Some(body.peer.getCaretPosition)) else insertPos)
+		               .map(new AtomicInteger(_))
 		val onOutput: String => Unit = s => SwingUtilities.invokeLater(() => {
-			if(!scroll) body.append(s)
-			else {
-				val current = body.caret.dot
-				body.selected = s
-				body.caret.dot = current + s.length
+			insertAt match {
+				case Some(pos) =>
+					try { body.peer.getDocument.insertString(pos.getAndAdd(s.length), s, null) }
+					catch { case _: Throwable => body.append(s) }
+				case None if !scroll => body.append(s)
+				case None =>
+					val current = body.caret.dot
+					body.selected = s
+					body.caret.dot = current + s.length
 			}
 		})
 		val onDone: () => Unit = () => SwingUtilities.invokeLater(() =>


### PR DESCRIPTION
## Changes since v1.2.30

- **Keyboard capture mode** (`Ctrl+Enter`/`Ctrl+F`/`Escape`) for composing commands and look targets inline, with live highlighting
- **Fixed `<` operator insertion point** — output is inserted at the caret position captured at call time, not after async streaming completes
- **Improved `<` and `|` external command selection handling** — `|` in capture mode pipes the full body; `<` always inserts at the correct position
- **Updated docs** to reflect `<` and `|` operator behavior changes
- **Help file converted to Unix line endings**

## Test plan
- [ ] Ctrl+Enter starts capture mode; Ctrl+Enter again executes; Escape cancels
- [ ] Ctrl+F in capture mode performs look/navigate
- [ ] `< cmd` inserts output at caret, not end of buffer
- [ ] `| cmd` in capture mode pipes full body content
- [ ] Help file opens without display issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)